### PR TITLE
feat: add delete session endpoint with authorization and ownership va…

### DIFF
--- a/backend/src/main/java/no/hiof/studytracker/Application.java
+++ b/backend/src/main/java/no/hiof/studytracker/Application.java
@@ -69,5 +69,9 @@ public class Application {
         app.put("/session/{sessionsId}", ctx -> {
             sessionController.updateSession(ctx);
         });
+
+        app.delete("session/{sessionId}", ctx -> {
+           sessionController.deleteSession(ctx);
+        });
     }
 }

--- a/backend/src/main/java/no/hiof/studytracker/controllers/SessionController.java
+++ b/backend/src/main/java/no/hiof/studytracker/controllers/SessionController.java
@@ -1,11 +1,10 @@
 package main.java.no.hiof.studytracker.controllers;
 
 import io.javalin.http.Context;
-import main.java.no.hiof.studytracker.DTOs.SessionDataDTO;
 import main.java.no.hiof.studytracker.DTOs.UpdateSessionDTO;
 import main.java.no.hiof.studytracker.exceptions.CustomException;
 import main.java.no.hiof.studytracker.exceptions.InvalidTokenException;
-import main.java.no.hiof.studytracker.exceptions.InvalidTokenSessionIdException;
+import main.java.no.hiof.studytracker.exceptions.SessionOwnershipException;
 import main.java.no.hiof.studytracker.service.SessionService;
 
 import java.util.*;
@@ -52,23 +51,50 @@ public class SessionController {
             cxt.status(200).json(Map.of(
                     "Message: ", "Session successfully updated"
             ));
-        } catch (InvalidTokenSessionIdException e) {
+        } catch (SessionOwnershipException e) {
             cxt.status(401).json(Map.of(
                "Message: ", e.getErrorCode()
             ));
-        }
-        catch (InvalidTokenException e) {
+        } catch (InvalidTokenException e) {
             cxt.status(403).json(Map.of(
                     "Message: ", e.getErrorCode()
             ));
-        }
-
-        catch (CustomException e) {
+        } catch (CustomException e) {
             cxt.status(404).json(Map.of(
                     "Message: ", e.getErrorCode()
             ));
         }
+    }
 
+
+    public void deleteSession(Context ctx) {
+        try {
+            int sessionId = Integer.parseInt(ctx.pathParam("sessionId"));
+            String token = ctx.header("Authorization").substring(7);
+            sessionService.deleteSessionForUser(token, sessionId);
+            ctx.status(204).json(Map.of(
+                    "Message:", "Session is successfully deteted",
+                    "Deleted: ", true
+            ));
+        } catch (InvalidTokenException e) {
+            ctx.status(401).json(Map.of(
+                    "Message: ", e.getErrorCode()
+            ));
+        } catch (SessionOwnershipException e) {
+            ctx.status(403).json(Map.of(
+                    "Message: ", e.getErrorCode()
+            ));
+        } catch (CustomException e) {
+            ctx.status(404).json(Map.of(
+                    "Message: ", e.getErrorCode()
+            ));
+        }
+
+        catch (Exception e) {
+            ctx.status(500).json(Map.of(
+                    "Message: ", e.getMessage()
+            ));
+        }
     }
 
 }

--- a/backend/src/main/java/no/hiof/studytracker/exceptions/SessionOwnershipException.java
+++ b/backend/src/main/java/no/hiof/studytracker/exceptions/SessionOwnershipException.java
@@ -1,10 +1,10 @@
 package main.java.no.hiof.studytracker.exceptions;
 
-public class InvalidTokenSessionIdException extends RuntimeException {
+public class SessionOwnershipException extends RuntimeException {
     private final String errorCode;
     private int sessionId;
 
-    public InvalidTokenSessionIdException(String message, String errorCode) {
+    public SessionOwnershipException(String message, String errorCode) {
         super(message);
         this.errorCode = errorCode;
     }

--- a/backend/src/main/java/no/hiof/studytracker/repository/UserDataRepository.java
+++ b/backend/src/main/java/no/hiof/studytracker/repository/UserDataRepository.java
@@ -285,4 +285,19 @@ public class UserDataRepository implements UserRepository {
         }
     }
 
+    public int deleteSession(int sessionId) {
+        String sql = "DELETE FROM sessions WHERE id = ?";
+
+        try (Connection connection = DB.getConnection()) {
+            PreparedStatement pstm = connection.prepareStatement(sql);
+            pstm.setInt(1, sessionId);
+
+            return pstm.executeUpdate();
+        } catch (SQLException e) {
+            throw new CustomException("Error when deleting session in DB", e);
+        }
+
+    }
+
+
 }

--- a/backend/src/main/java/no/hiof/studytracker/service/SessionService.java
+++ b/backend/src/main/java/no/hiof/studytracker/service/SessionService.java
@@ -6,7 +6,7 @@ import main.java.no.hiof.studytracker.DTOs.SessionResponseDTO;
 import main.java.no.hiof.studytracker.DTOs.UpdateSessionDTO;
 import main.java.no.hiof.studytracker.exceptions.CustomException;
 import main.java.no.hiof.studytracker.exceptions.InvalidTokenException;
-import main.java.no.hiof.studytracker.exceptions.InvalidTokenSessionIdException;
+import main.java.no.hiof.studytracker.exceptions.SessionOwnershipException;
 import main.java.no.hiof.studytracker.model.Session;
 import main.java.no.hiof.studytracker.repository.UserDataRepository;
 
@@ -89,13 +89,6 @@ public class SessionService {
     }
 
 
-    /*
-        1. Autentiser token
-        2. Hvis token er gyldig sjekk om den tilhører brukeren som ber om oppdateringen
-        3. Oppdater kun de feltene som brukeren ber endring om (la stå gamle verdier hvis de ikke er med i forespørselen)
-    */
-
-
     public boolean doesTokenMatchUser(String token, int sessionId) {
         int userIdByToken = userDataRepository.getUserIdByToken(token);
         int userIdBySessionId = userDataRepository.getUserIdBySessionId(sessionId);
@@ -176,7 +169,7 @@ public class SessionService {
         }
 
         // Token does not match session owner
-        throw new InvalidTokenSessionIdException("Given token and session-id doesn't match user", "INVALID_TOKEN_SESSION_ID");
+        throw new SessionOwnershipException("Given token and session-id doesn't match user", "INVALID_TOKEN_SESSION_ID");
     }
 
 
@@ -184,7 +177,7 @@ public class SessionService {
         if (userDataRepository.doesTokenExist(token)) {
             updateSession(updateSessionDTO, token, sessionId);
         } else {
-            throw new InvalidTokenException("Unauthorized token is given", "UNAUTHENTICATED_TOKEN");
+            throw new InvalidTokenException("Unauthorized token is given", "UNAUTHORIZED_TOKEN");
         }
     }
 
@@ -208,6 +201,22 @@ public class SessionService {
             return true;
         }
         return false;
+    }
+
+    public void deleteSessionForUser(String token, int sessionId) {
+        if (userDataRepository.doesTokenExist(token)) {
+            if (doesTokenMatchUser(token, sessionId)) {
+                int valueOfDeleteSessionQuery = userDataRepository.deleteSession(sessionId);
+                if (valueOfDeleteSessionQuery == 0) {
+                    throw new CustomException("Session couldn't be deleted", "NON_EXISTENT_SESSION_ID");
+                }
+            }
+            else {
+                throw new SessionOwnershipException("Invalid token and sessionId, therefore can't delete session", "INVALID_TOKEN_SESSION_ID");
+            }
+        } else {
+            throw new InvalidTokenException("Token couldn't be verified", "UNAUTHORIZED_TOKEN");
+        }
     }
 
 }


### PR DESCRIPTION
…lidation

- authorize request using session token
- validate session ownership before deletion
- delete session by token and session ID
- rename InvalidTokenSessionIdException → SessionOwnershipException

throw:
- CustomException for non-existent session
- SessionOwnershipException for invalid token–session ownership
- InvalidTokenException for unauthorized token